### PR TITLE
Add updateQuery method to OpenCDXAdrService

### DIFF
--- a/src/main/java/cdx/opencdx/adr/controller/QueryController.java
+++ b/src/main/java/cdx/opencdx/adr/controller/QueryController.java
@@ -2,12 +2,10 @@ package cdx.opencdx.adr.controller;
 
 
 import cdx.opencdx.adr.dto.ADRQuery;
-import cdx.opencdx.adr.dto.Query;
 import cdx.opencdx.adr.dto.SavedQuery;
 import cdx.opencdx.adr.model.TinkarConceptModel;
 import cdx.opencdx.adr.service.OpenCDXAdrService;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -16,7 +14,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 
@@ -102,6 +99,13 @@ public class QueryController {
         log.info("Received save query request");
         return ResponseEntity.ok(adrService.saveQuery(save));
     }
+
+    @PutMapping("/update")
+    public ResponseEntity<SavedQuery>updateQuery(@RequestBody SavedQuery save) throws JsonProcessingException {
+        log.info("Received save query request");
+        return ResponseEntity.ok(adrService.updateQuery(save));
+    }
+
 
     @GetMapping("/list")
     public ResponseEntity<List<SavedQuery>> listQueries() throws JsonProcessingException {

--- a/src/main/java/cdx/opencdx/adr/service/OpenCDXAdrService.java
+++ b/src/main/java/cdx/opencdx/adr/service/OpenCDXAdrService.java
@@ -21,7 +21,6 @@ import cdx.opencdx.adr.model.TinkarConceptModel;
 import cdx.opencdx.grpc.data.ANFStatement;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import java.io.PrintWriter;
 import java.util.List;
 
 /**
@@ -66,6 +65,13 @@ public interface OpenCDXAdrService {
      */
     SavedQuery saveQuery(SavedQuery save) throws JsonProcessingException;
 
+    /**
+     * Updates a SavedQuery object.
+     *
+     * @param save The SavedQuery object to update.
+     * @return The updated SavedQuery object.
+     */
+    SavedQuery updateQuery(SavedQuery save) throws JsonProcessingException;
     /**
      * Retrieves a list of saved queries.
      *

--- a/src/main/java/cdx/opencdx/adr/service/impl/OpenCDXAdrServiceImpl.java
+++ b/src/main/java/cdx/opencdx/adr/service/impl/OpenCDXAdrServiceImpl.java
@@ -35,10 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 
 /**
@@ -193,6 +190,18 @@ public class OpenCDXAdrServiceImpl implements OpenCDXAdrService {
         model = this.savedQueryRepository.save(model);
 
         return new SavedQuery(model.getId(), model.getName(), save.getQuery());
+    }
+
+    public SavedQuery updateQuery(SavedQuery save) throws JsonProcessingException {
+        Optional<SavedQueryModel> optionalModel = this.savedQueryRepository.findById(save.getId());
+
+        if(optionalModel.isPresent()) {
+            optionalModel.get().setName(save.getName());
+            optionalModel.get().setContent(this.mapper.writerWithDefaultPrettyPrinter().writeValueAsString(save.getQuery()));
+            SavedQueryModel model = this.savedQueryRepository.save(optionalModel.get());
+            return new SavedQuery(model.getId(), model.getName(), save.getQuery());
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Implemented the `updateQuery` method in `OpenCDXAdrServiceImpl` to allow updating existing saved queries. Updated the `QueryController` to handle PUT requests for updating saved queries and added the corresponding method description in the `OpenCDXAdrService` interface.