### PR TITLE
Add unit conversions for volume measurements

### DIFF
--- a/src/main/java/cdx/opencdx/adr/service/OpenCDXIKMService.java
+++ b/src/main/java/cdx/opencdx/adr/service/OpenCDXIKMService.java
@@ -23,6 +23,12 @@ public interface OpenCDXIKMService {
     String UNIT_CELSIUS = "ab65a92d-b6d8-3ab1-9324-45b72ef3c09a";
     String UNIT_FAHRENHEIT = "ced62ffd-e8cc-3ffb-9722-99e9b402e508";
 
+    String UNIT_MILILITER = "43a354f0-94a6-3e47-94ac-47ca3dd48142";
+    String UNIT_LITER = "fab03cd1-51c2-3831-85a9-8e9966ecb765";
+    String UNIT_FLUID_OUNCE = "263d811a-3262-30c8-805e-1729b7baea80";
+    String UNIT_PINT = "35830f24-079f-3090-928a-64c5564bc828";
+    String UNIT_GALLON = "a5205229-81ab-3c0c-b4d2-41cd5a69761d";
+
     String UNIT_CALENDAR_TIME = "b5ba88ba-22d5-37fe-a9a1-b82c377e0212";
     String UNIT_DATE_TIME = "f81f5dc6-aaa3-372a-aa2d-5934fe79dfb0";
     String UNIT_MILLISECONDS = "86b3f8c4-9a2f-35ca-9183-bb8c0090930e";

--- a/src/main/java/cdx/opencdx/adr/service/impl/ConversionServiceImpl.java
+++ b/src/main/java/cdx/opencdx/adr/service/impl/ConversionServiceImpl.java
@@ -129,6 +129,10 @@ public class ConversionServiceImpl implements ConversionService {
                     UUID.fromString(OpenCDXIKMServiceImpl.UNIT_POUNDS);
             case OpenCDXIKMServiceImpl.UNIT_CELSIUS ->
                     UUID.fromString(OpenCDXIKMServiceImpl.UNIT_FAHRENHEIT);
+            case OpenCDXIKMService.UNIT_MILILITER -> // milliliters
+                    UUID.fromString(OpenCDXIKMService.UNIT_FLUID_OUNCE);
+            case OpenCDXIKMService.UNIT_LITER -> // liters
+                    UUID.fromString(OpenCDXIKMService.UNIT_PINT);
             default -> measure.getSemantic().getConceptId();
         };
     }
@@ -147,6 +151,12 @@ public class ConversionServiceImpl implements ConversionService {
                     UUID.fromString(OpenCDXIKMServiceImpl.UNIT_KILOGRAMS);
             case OpenCDXIKMServiceImpl.UNIT_FAHRENHEIT ->
                     UUID.fromString(OpenCDXIKMServiceImpl.UNIT_CELSIUS);
+            case OpenCDXIKMService.UNIT_FLUID_OUNCE -> // fluid ounces
+                    UUID.fromString(OpenCDXIKMService.UNIT_MILILITER);
+            case OpenCDXIKMService.UNIT_PINT -> // pints
+                    UUID.fromString(OpenCDXIKMService.UNIT_LITER);
+            case OpenCDXIKMService.UNIT_GALLON ->
+                    UUID.fromString(OpenCDXIKMService.UNIT_LITER);
             default -> measure.getSemantic().getConceptId();
         };
     }
@@ -197,7 +207,87 @@ public class ConversionServiceImpl implements ConversionService {
                     convertToCelsius(unit, value);
             case OpenCDXIKMService.UNIT_FAHRENHEIT -> // Fahrenheit
                     convertToFahrenheit(unit, value);
+            case OpenCDXIKMService.UNIT_MILILITER -> // milliliters
+                    convertToMilliliters(unit, value);
+            case OpenCDXIKMService.UNIT_LITER -> // liters
+                    convertToLiters(unit, value);
+            case OpenCDXIKMService.UNIT_FLUID_OUNCE -> // fluid ounces
+                    convertToFluidOunces(unit, value);
+            case OpenCDXIKMService.UNIT_PINT -> // pints
+                    convertToPints(unit, value);
+            case OpenCDXIKMService.UNIT_GALLON -> // gallons
+                    convertToGallons(unit, value);
             default -> value;
+        };
+    }
+
+    private Double convertToGallons(UUID unit, Double value) {
+        return switch (unit.toString()) {
+            case OpenCDXIKMService.UNIT_LITER -> // liters
+                    value / 3.78541;
+            case OpenCDXIKMService.UNIT_MILILITER -> // milliliters
+                    value / 3785.41;
+            case OpenCDXIKMService.UNIT_FLUID_OUNCE -> // fluid ounces
+                    value / 128;
+            case OpenCDXIKMService.UNIT_PINT -> // pints
+                    value / 8;
+            default -> null;
+        };
+    }
+
+    private Double convertToPints(UUID unit, Double value) {
+        return switch (unit.toString()) {
+            case OpenCDXIKMService.UNIT_LITER -> // liters
+                    value * 2.11338;
+            case OpenCDXIKMService.UNIT_MILILITER -> // milliliters
+                    value * 0.00211338;
+            case OpenCDXIKMService.UNIT_FLUID_OUNCE -> // fluid ounces
+                    value / 16;
+            case OpenCDXIKMService.UNIT_GALLON -> // gallons
+                    value * 8;
+            default -> null;
+        };
+    }
+
+    private Double convertToFluidOunces(UUID unit, Double value) {
+        return switch (unit.toString()) {
+            case OpenCDXIKMService.UNIT_LITER -> // liters
+                    value * 33.814;
+            case OpenCDXIKMService.UNIT_MILILITER -> // milliliters
+                    value * 0.033814;
+            case OpenCDXIKMService.UNIT_PINT -> // pints
+                    value * 16;
+            case OpenCDXIKMService.UNIT_GALLON -> // gallons
+                    value * 128;
+            default -> null;
+        };
+    }
+
+    private Double convertToLiters(UUID unit, Double value) {
+        return switch (unit.toString()) {
+            case OpenCDXIKMService.UNIT_MILILITER -> // milliliters
+                    value / 1000;
+            case OpenCDXIKMService.UNIT_FLUID_OUNCE -> // fluid ounces
+                    value / 33.814;
+            case OpenCDXIKMService.UNIT_PINT -> // pints
+                    value / 2.11338;
+            case OpenCDXIKMService.UNIT_GALLON -> // gallons
+                    value / 0.264172;
+            default -> null;
+        };
+    }
+
+    private Double convertToMilliliters(UUID unit, Double value) {
+        return switch (unit.toString()) {
+            case OpenCDXIKMService.UNIT_LITER -> // liters
+                    value * 1000;
+            case OpenCDXIKMService.UNIT_FLUID_OUNCE -> // fluid ounces
+                    value * 29.5735;
+            case OpenCDXIKMService.UNIT_PINT -> // pints
+                    value * 473.176;
+            case OpenCDXIKMService.UNIT_GALLON -> // gallons
+                    value * 3785.41;
+            default -> null;
         };
     }
 

--- a/src/main/java/cdx/opencdx/adr/service/impl/IKMInterfaceImpl.java
+++ b/src/main/java/cdx/opencdx/adr/service/impl/IKMInterfaceImpl.java
@@ -94,6 +94,12 @@ public class IKMInterfaceImpl implements IKMInterface, AutoCloseable {
         addConceptIfMissing(OpenCDXIKMService.UNIT_CELSIUS, "Celsius", "258710007 | Degrees Celsius (qualifier value)");
         addConceptIfMissing(OpenCDXIKMService.UNIT_FAHRENHEIT, "Fahrenheit", "258712004 | Degrees Fahrenheit (qualifier value)");
 
+        addConceptIfMissing(OpenCDXIKMService.UNIT_MILILITER, "milliliter", "258773002 | Milliliter (qualifier value)");
+        addConceptIfMissing(OpenCDXIKMService.UNIT_LITER, "liter", "258770004 | Liter (qualifier value)");
+        addConceptIfMissing(OpenCDXIKMService.UNIT_FLUID_OUNCE, "fluid ounce", "282118007 | fluid ounce (qualifier value)");
+        addConceptIfMissing(OpenCDXIKMService.UNIT_PINT, "pint", "282119004 | pint (qualifier value)");
+        addConceptIfMissing(OpenCDXIKMService.UNIT_GALLON, "gallon", "282120005 | gallon (qualifier value)");
+
     }
 
     @Override

--- a/src/main/java/cdx/opencdx/adr/service/impl/MapInterfaceImpl.java
+++ b/src/main/java/cdx/opencdx/adr/service/impl/MapInterfaceImpl.java
@@ -121,6 +121,11 @@ public class MapInterfaceImpl implements IKMInterface {
         addConceptIfMissing(OpenCDXIKMService.UNIT_NO, "no", "373067005 | No (qualifier value)");
         addConceptIfMissing(OpenCDXIKMService.UNIT_CELSIUS, "celsius", "258710007 | Degrees Celsius (qualifier value)");
         addConceptIfMissing(OpenCDXIKMService.UNIT_FAHRENHEIT, "fahrenheit", "258712004 | Degrees Fahrenheit (qualifier value)");
+        addConceptIfMissing(OpenCDXIKMService.UNIT_MILILITER, "milliliter", "258773002 | Milliliter (qualifier value)");
+        addConceptIfMissing(OpenCDXIKMService.UNIT_LITER, "liter", "258770004 | Liter (qualifier value)");
+        addConceptIfMissing(OpenCDXIKMService.UNIT_FLUID_OUNCE, "fluid ounce", "282118007 | fluid ounce (qualifier value)");
+        addConceptIfMissing(OpenCDXIKMService.UNIT_PINT, "pint", "282119004 | pint (qualifier value)");
+        addConceptIfMissing(OpenCDXIKMService.UNIT_GALLON, "gallon", "282120005 | gallon (qualifier value)");
 
 
         // Test Kits

--- a/src/main/java/cdx/opencdx/adr/service/impl/OpenCDXAdrServiceImpl.java
+++ b/src/main/java/cdx/opencdx/adr/service/impl/OpenCDXAdrServiceImpl.java
@@ -164,6 +164,11 @@ public class OpenCDXAdrServiceImpl implements OpenCDXAdrService {
         this.blockConcepts.add(UUID.fromString(OpenCDXIKMService.UNIT_MILLISECONDS)); // Unit of Calendar Time
         this.blockConcepts.add(UUID.fromString(OpenCDXIKMService.UNIT_CELSIUS)); // Unit of Calendar Time
         this.blockConcepts.add(UUID.fromString(OpenCDXIKMService.UNIT_FAHRENHEIT)); // Unit of Calendar Time
+        this.blockConcepts.add(UUID.fromString(OpenCDXIKMService.UNIT_MILILITER)); // Unit of Calendar Time
+        this.blockConcepts.add(UUID.fromString(OpenCDXIKMService.UNIT_LITER)); // Unit of Calendar Time
+        this.blockConcepts.add(UUID.fromString(OpenCDXIKMService.UNIT_PINT)); // Unit of Calendar Time
+        this.blockConcepts.add(UUID.fromString(OpenCDXIKMService.UNIT_FLUID_OUNCE)); // Unit of Calendar Time
+        this.blockConcepts.add(UUID.fromString(OpenCDXIKMService.UNIT_GALLON)); // Unit of Calendar Time
 
     }
 


### PR DESCRIPTION
Implemented conversions and concept additions for milliliters, liters, fluid ounces, pints, and gallons. This includes updates to conversion logic and semantic concept IDs across relevant service classes.